### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Create a bot, ask it about your network. Details/examples to be added. Ask your 
     * CloudGenix Python SDK >= 5.2.1b1 - <https://github.com/CloudGenix/sdk-python>
     * Tabulate - <https://github.com/astanin/python-tabulate>
     * IDNA - <https://github.com/kjd/idna>
-    * FuzzyWuzzy - <https://github.com/seatgeek/fuzzywuzzy>
+    * RapidFuzz - <https://github.com/rhasspy/rapidfuzz>
     * Pandas - <https://pandas.pydata.org/>
 
 #### License

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='slackbot-cloudgenix',
             'slackbot',
             'tabulate',
             'idna',
-            'fuzzywuzzy',
+            'rapidfuzz',
             'pandas'
       ],
       packages=['slackbot_cloudgenix'],

--- a/slackbot_cloudgenix/__init__.py
+++ b/slackbot_cloudgenix/__init__.py
@@ -6,7 +6,7 @@ import re
 import inspect
 import random
 
-from fuzzywuzzy import fuzz, process
+from rapidfuzz import fuzz, process
 import cloudgenix
 import cloudgenix_idname
 


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it faster than FuzzyWuzzy.